### PR TITLE
Fixed accessibility problem with modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-popover-tooltip",
-  "version": "1.1.1",
+  "version": "1.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-popover-tooltip",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "ReactNative component showing tooltip with menu items.",
   "main": "src/index.js",
   "scripts": {

--- a/src/PopoverTooltipItem.js
+++ b/src/PopoverTooltipItem.js
@@ -26,6 +26,7 @@ type Props = {
   label: Label,
   containerStyle: ?StyleObj,
   labelStyle: ?StyleObj,
+  accessibilityLabel : PropTypes.string,
 };
 class PopoverTooltipItem extends React.PureComponent<Props> {
 
@@ -35,6 +36,7 @@ class PopoverTooltipItem extends React.PureComponent<Props> {
     label: labelPropType.isRequired,
     containerStyle: ViewPropTypes.style,
     labelStyle: Text.propTypes.style,
+    accessibilityLabel: PropTypes.string,
   };
   static defaultProps = {
     labelStyle: null,
@@ -43,7 +45,7 @@ class PopoverTooltipItem extends React.PureComponent<Props> {
 
   render() {
     const label = typeof this.props.label === 'string'
-      ? <Text accessibilityLabel={this.props.label.replace(/\n/g, ' ')} style={this.props.labelStyle}>{this.props.label}</Text>
+      ? <Text accessibilityLabel={this.props.accessibilityLabel} style={this.props.labelStyle}>{this.props.label}</Text>
       : this.props.label();
     return (
       <View style={[styles.itemContainer, this.props.containerStyle]}>

--- a/src/PopoverTooltipItem.js
+++ b/src/PopoverTooltipItem.js
@@ -43,7 +43,7 @@ class PopoverTooltipItem extends React.PureComponent<Props> {
 
   render() {
     const label = typeof this.props.label === 'string'
-      ? <Text accessibilityLabel={this.props.label.replace(/\n/g, ' ') + '\nToque duas vezes para continuar.'} style={this.props.labelStyle}>{this.props.label}</Text>
+      ? <Text accessibilityLabel={this.props.label.replace(/\n/g, ' ')} style={this.props.labelStyle}>{this.props.label}</Text>
       : this.props.label();
     return (
       <View style={[styles.itemContainer, this.props.containerStyle]}>

--- a/src/PopoverTooltipItem.js
+++ b/src/PopoverTooltipItem.js
@@ -43,7 +43,7 @@ class PopoverTooltipItem extends React.PureComponent<Props> {
 
   render() {
     const label = typeof this.props.label === 'string'
-      ? <Text style={this.props.labelStyle}>{this.props.label}</Text>
+      ? <Text accessibilityLabel={this.props.label.replace(/\n/g, ' ') + '\nToque duas vezes para continuar.'} style={this.props.labelStyle}>{this.props.label}</Text>
       : this.props.label();
     return (
       <View style={[styles.itemContainer, this.props.containerStyle]}>

--- a/src/index.js
+++ b/src/index.js
@@ -294,7 +294,7 @@ class PopoverTooltip extends React.PureComponent<Props, State> {
           onRequestClose={this.props.onRequestClose}
           transparent
         >
-          <View style={{flex: 1}} accessible={true} accessibilityLabel={(this.props.accessibilityLabel || '') + '\nToque duas vezes para continuar.'}>
+          <View style={{flex: 1}} accessible={true} accessibilityLabel={(this.props.accessibilityLabel || '')}>
             <TouchableOpacity style={{flex: 1}} onPress={this.toggle}>
               <Animated.View style={[
                 styles.overlay,

--- a/src/index.js
+++ b/src/index.js
@@ -294,61 +294,65 @@ class PopoverTooltip extends React.PureComponent<Props, State> {
           onRequestClose={this.props.onRequestClose}
           transparent
         >
-          <Animated.View style={[
-            styles.overlay,
-            this.props.overlayStyle,
-            { opacity: this.state.opacity },
-          ]}>
-            <TouchableOpacity
-              activeOpacity={1}
-              focusedOpacity={1}
-              style={styles.button}
-              onPress={this.toggle}
-            >
-              <Animated.View
-                style={[
-                  styles.tooltipContainer,
-                  this.props.tooltipContainerStyle,
-                  tooltipContainerStyle,
-                ]}
-              >
-                <View
-                  onLayout={this.onInnerContainerLayout}
-                  style={styles.innerContainer}
+          <View style={{flex: 1}} accessible={true} accessibilityLabel={(this.props.accessibilityLabel || '') + '\nToque duas vezes para continuar.'}>
+            <TouchableOpacity style={{flex: 1}} onPress={this.toggle}>
+              <Animated.View style={[
+                styles.overlay,
+                this.props.overlayStyle,
+                { opacity: this.state.opacity },
+              ]}>
+                <TouchableOpacity
+                  activeOpacity={1}
+                  focusedOpacity={1}
+                  style={styles.button}
+                  onPress={this.toggle}
                 >
-                  {triangleUp}
-                  <View style={[
-                    styles.allItemContainer,
-                    this.props.tooltipContainerStyle,
-                  ]}>
-                    {items}
-                  </View>
-                  {triangleDown}
-                </View>
+                  <Animated.View
+                    style={[
+                      styles.tooltipContainer,
+                      this.props.tooltipContainerStyle,
+                      tooltipContainerStyle,
+                    ]}
+                  >
+                    <View
+                      onLayout={this.onInnerContainerLayout}
+                      style={styles.innerContainer}
+                    >
+                      {triangleUp}
+                      <View style={[
+                        styles.allItemContainer,
+                        this.props.tooltipContainerStyle,
+                      ]}>
+                        {items}
+                      </View>
+                      {triangleDown}
+                    </View>
+                  </Animated.View>
+                </TouchableOpacity>
+              </Animated.View>
+              <Animated.View style={{
+                position: 'absolute',
+                left: this.state.x,
+                top: this.state.y,
+                width: this.state.width,
+                height: this.state.height,
+                backgroundColor: 'transparent',
+                opacity: this.state.buttonComponentOpacity, // At the first frame, the button will be rendered
+                                                            // in the top-left corner. So we dont render it
+                                                            // until its position has been calculated.
+                transform: [
+                  { scale: this.state.buttonComponentContainerScale },
+                ],
+              }}>
+                <TouchableOpacity
+                  onPress={this.toggle}
+                  activeOpacity={1.0}
+                >
+                  {this.props.buttonComponent}
+                </TouchableOpacity>
               </Animated.View>
             </TouchableOpacity>
-          </Animated.View>
-          <Animated.View style={{
-            position: 'absolute',
-            left: this.state.x,
-            top: this.state.y,
-            width: this.state.width,
-            height: this.state.height,
-            backgroundColor: 'transparent',
-            opacity: this.state.buttonComponentOpacity, // At the first frame, the button will be rendered
-                                                        // in the top-left corner. So we dont render it
-                                                        // until its position has been calculated.
-            transform: [
-              { scale: this.state.buttonComponentContainerScale },
-            ],
-          }}>
-            <TouchableOpacity
-              onPress={this.toggle}
-              activeOpacity={1.0}
-            >
-              {this.props.buttonComponent}
-            </TouchableOpacity>
-          </Animated.View>
+          </View>
         </Modal>
       </TouchableOpacity>
     );

--- a/src/index.js
+++ b/src/index.js
@@ -239,6 +239,7 @@ class PopoverTooltip extends React.PureComponent<Props, State> {
         <PopoverTooltipItem
           key={index}
           label={item.label}
+          accessibilityLabel={item.accessibilityLabel}
           onPressUserCallback={item.onPress}
           onPress={this.onPressItem}
           containerStyle={classes}
@@ -294,7 +295,7 @@ class PopoverTooltip extends React.PureComponent<Props, State> {
           onRequestClose={this.props.onRequestClose}
           transparent
         >
-          <View style={{flex: 1}} accessible={true} accessibilityLabel={(this.props.accessibilityLabel || '')}>
+          <View style={{flex: 1}} accessible={true} accessibilityLabel={this.props.accessibilityLabel}>
             <TouchableOpacity style={{flex: 1}} onPress={this.toggle}>
               <Animated.View style={[
                 styles.overlay,


### PR DESCRIPTION
Customers with screen readers active were getting stuck in screens when the tooltip was presented and they had to close the app to restart the navigation.

We would like to let they know how to close the tooltip and create an easier way to do so.