### PR TITLE
Adds a timeout to modal open on mount

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ import {
   Text,
   Easing,
   ViewPropTypes,
+  InteractionManager,
 } from 'react-native';
 import PropTypes from 'prop-types';
 import invariant from 'invariant';
@@ -138,7 +139,7 @@ class PopoverTooltip extends React.PureComponent<Props, State> {
 
   componentDidMount() {
     if (this.props.showTooltipOnMount) {
-      setTimeout(this.openModal, 1000);
+      InteractionManager.runAfterInteractions(this.openModal);
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -138,7 +138,7 @@ class PopoverTooltip extends React.PureComponent<Props, State> {
 
   componentDidMount() {
     if (this.props.showTooltipOnMount) {
-      this.openModal();
+      setTimeout(this.openModal, 1000);
     }
   }
 


### PR DESCRIPTION
This is necessary due to the way the tooltip is positioned in the screen doesn't follow the position of the target component.

This change doesn't solve the problem entirely but reduces it's impact - mostly involved in screen animations and the render of the tooltip.